### PR TITLE
Initializes Go time tracking CLI tool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,71 @@
-# go-playground
+# Zeiterfassung CLI
 
-Überblick was gelernt wurde
+Ein einfaches Kommandozeilen-Tool zur Zeiterfassung und zum Auslesen der aktuellen Zeit von einer Webseite.
+
+## Features
+
+- **Start**: Beginnt eine Zeiterfassungssitzung.
+- **Stop**: Beendet die aktuelle Zeiterfassungssitzung.
+- **Status**: Zeigt den aktuellen Status der Zeiterfassung.
+- **Fetch**: Liest die aktuelle Zeit von einer angegebenen Webseite aus.
+
+## Installation
+
+1. Repository klonen:
+   ```sh
+   git clone https://github.com/dein-benutzername/zeiterfassung.git
+   cd zeiterfassung
+   ```
+
+2. Abhängigkeiten installieren:
+   ```sh
+   go mod tidy
+   ```
+
+3. Build:
+   ```sh
+   go build -o zeiterfassung
+   ```
+
+## Nutzung
+
+```sh
+./zeiterfassung <befehl> [argumente]
+```
+
+### Beispiele
+
+- **Zeit von Webseite auslesen:**
+  ```sh
+  ./zeiterfassung fetch https://example.com
+  ```
+
+- **Zeiterfassung starten:**
+  ```sh
+  ./zeiterfassung start
+  ```
+
+- **Zeiterfassung stoppen:**
+  ```sh
+  ./zeiterfassung stop
+  ```
+
+- **Status anzeigen:**
+  ```sh
+  ./zeiterfassung status
+  ```
+
+## Flags
+
+Jeder Befehl unterstützt ggf. weitere Flags. Mit `--help` erhältst du eine Übersicht:
+```sh
+./zeiterfassung <befehl> --help
+```
+
+## Mitwirken
+
+Pull Requests und Vorschläge sind willkommen!
+
+## Lizenz
+
+MIT License

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"zeiterfassung/zeitfetch"
 
@@ -13,11 +14,23 @@ var FetchCmd = &cobra.Command{
 	Short: "Liest die aktuelle Zeit von einer Webseite aus",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if verbose {
+			log.Printf("Starte Zeitabfrage für URL: %s", args[0])
+		}
 		time, err := zeitfetch.FetchTimeFromWeb(args[0])
 		if err != nil {
-			fmt.Println("Fehler beim Auslesen der Zeit:", err)
+			if verbose {
+				log.Printf("Fehler beim Auslesen der Zeit: %v", err)
+			}
 			os.Exit(1)
+		}
+		if verbose {
+			log.Printf("Gefundene Zeit: %s", time)
 		}
 		fmt.Println("Gefundene Zeit:", time)
 	},
+}
+
+func init() {
+	FetchCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Aktiviere ausführliche Logausgabe")
 }

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"zeiterfassung/zeitfetch"
+
+	"github.com/spf13/cobra"
+)
+
+var FetchCmd = &cobra.Command{
+	Use:   "fetch <url>",
+	Short: "Liest die aktuelle Zeit von einer Webseite aus",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		time, err := zeitfetch.FetchTimeFromWeb(args[0])
+		if err != nil {
+			fmt.Println("Fehler beim Auslesen der Zeit:", err)
+			os.Exit(1)
+		}
+		fmt.Println("Gefundene Zeit:", time)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "zeiterfassung",
+	Short: "Zeiterfassung CLI",
+	Long:  `Ein CLI-Tool zur Zeiterfassung und Auswertung von Webseiten-Zeiten.`,
+}
+
+func init() {
+	RootCmd.AddCommand(StartCmd, StopCmd, StatusCmd, FetchCmd)
+}
+
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,9 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	verbose bool
 )
 
 var RootCmd = &cobra.Command{
@@ -15,10 +20,14 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(StartCmd, StopCmd, StatusCmd, FetchCmd)
+	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Aktiviere ausführliche Logausgabe")
 }
 
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
+		if verbose {
+			log.Printf("Fehler beim Ausführen des RootCmd: %v", err)
+		}
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var StartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Startet die Zeiterfassung",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Zeiterfassung gestartet.")
+	},
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,7 @@ var StartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Startet die Zeiterfassung",
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Println("Zeiterfassung gestartet.")
 		fmt.Println("Zeiterfassung gestartet.")
 	},
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var StatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Zeigt den Status der Zeiterfassung",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Status der Zeiterfassung anzeigen.")
+	},
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,7 @@ var StatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Zeigt den Status der Zeiterfassung",
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Println("Status der Zeiterfassung anzeigen.")
 		fmt.Println("Status der Zeiterfassung anzeigen.")
 	},
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var StopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stoppt die Zeiterfassung",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Zeiterfassung gestoppt.")
+	},
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -10,6 +11,7 @@ var StopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stoppt die Zeiterfassung",
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Println("Zeiterfassung gestoppt.")
 		fmt.Println("Zeiterfassung gestoppt.")
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module zeiterfassung
+
+go 1.24.3
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	golang.org/x/net v0.40.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
+golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helloworld.go
+++ b/helloworld.go
@@ -1,1 +1,0 @@
-// start here

--- a/main.go
+++ b/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"zeiterfassung/zeitfetch"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:   "zeiterfassung",
+		Short: "Zeiterfassung CLI",
+		Long:  `Ein CLI-Tool zur Zeiterfassung und Auswertung von Webseiten-Zeiten.`,
+	}
+
+	var startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Startet die Zeiterfassung",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Zeiterfassung gestartet.")
+		},
+	}
+
+	var stopCmd = &cobra.Command{
+		Use:   "stop",
+		Short: "Stoppt die Zeiterfassung",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Zeiterfassung gestoppt.")
+		},
+	}
+
+	var statusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Zeigt den Status der Zeiterfassung",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Status der Zeiterfassung anzeigen.")
+		},
+	}
+
+	var fetchCmd = &cobra.Command{
+		Use:   "fetch <url>",
+		Short: "Liest die aktuelle Zeit von einer Webseite aus",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			time, err := zeitfetch.FetchTimeFromWeb(args[0])
+			if err != nil {
+				fmt.Println("Fehler beim Auslesen der Zeit:", err)
+				os.Exit(1)
+			}
+			fmt.Println("Gefundene Zeit:", time)
+		},
+	}
+
+	rootCmd.AddCommand(startCmd, stopCmd, statusCmd, fetchCmd)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,61 +1,10 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"zeiterfassung/zeitfetch"
-
-	"github.com/spf13/cobra"
+	"zeiterfassung/cmd"
 )
 
 func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "zeiterfassung",
-		Short: "Zeiterfassung CLI",
-		Long:  `Ein CLI-Tool zur Zeiterfassung und Auswertung von Webseiten-Zeiten.`,
-	}
-
-	var startCmd = &cobra.Command{
-		Use:   "start",
-		Short: "Startet die Zeiterfassung",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Zeiterfassung gestartet.")
-		},
-	}
-
-	var stopCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "Stoppt die Zeiterfassung",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Zeiterfassung gestoppt.")
-		},
-	}
-
-	var statusCmd = &cobra.Command{
-		Use:   "status",
-		Short: "Zeigt den Status der Zeiterfassung",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Status der Zeiterfassung anzeigen.")
-		},
-	}
-
-	var fetchCmd = &cobra.Command{
-		Use:   "fetch <url>",
-		Short: "Liest die aktuelle Zeit von einer Webseite aus",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			time, err := zeitfetch.FetchTimeFromWeb(args[0])
-			if err != nil {
-				fmt.Println("Fehler beim Auslesen der Zeit:", err)
-				os.Exit(1)
-			}
-			fmt.Println("Gefundene Zeit:", time)
-		},
-	}
-
-	rootCmd.AddCommand(startCmd, stopCmd, statusCmd, fetchCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	cmd.RootCmd.AddCommand(cmd.StartCmd, cmd.StopCmd, cmd.StatusCmd, cmd.FetchCmd)
+	cmd.Execute()
 }

--- a/zeitfetch/zeitfetch.go
+++ b/zeitfetch/zeitfetch.go
@@ -1,0 +1,52 @@
+package zeitfetch
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// FetchTimeFromWeb extrahiert die Zeit aus einem <div id="Timeslot">...</div> mit HTML-Parser
+func FetchTimeFromWeb(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("Fehler beim Parsen des HTML: %v", err)
+	}
+
+	var timeslot string
+	var f func(*html.Node)
+	f = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "div" {
+			for _, a := range n.Attr {
+				if a.Key == "id" && a.Val == "Timeslot" {
+					if n.FirstChild != nil {
+						timeslot = n.FirstChild.Data
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
+		}
+	}
+	f(doc)
+
+	if timeslot == "" {
+		return "", fmt.Errorf("Kein <div id=Timeslot> gefunden oder leer")
+	}
+	return timeslot, nil
+}

--- a/zeitfetch/zeitfetch_test.go
+++ b/zeitfetch/zeitfetch_test.go
@@ -1,0 +1,64 @@
+package zeitfetch
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchTimeFromWeb(t *testing.T) {
+	tests := []struct {
+		name           string
+		html           string
+		erwartet       string
+		erwartetFehler bool
+	}{
+		{
+			name:           "Korrektes Timeslot-Div",
+			html:           `<html><body><div id="Timeslot">12:34:56</div></body></html>`,
+			erwartet:       "12:34:56",
+			erwartetFehler: false,
+		},
+		{
+			name:           "Kein Timeslot-Div",
+			html:           `<html><body><div id="Other">12:34:56</div></body></html>`,
+			erwartet:       "",
+			erwartetFehler: true,
+		},
+		{
+			name:           "Leeres Timeslot-Div",
+			html:           `<html><body><div id="Timeslot"></div></body></html>`,
+			erwartet:       "",
+			erwartetFehler: true,
+		},
+		{
+			name:           "Timeslot-Div mit Leerzeichen",
+			html:           `<html><body><div id="Timeslot"> 12:34:56 </div></body></html>`,
+			erwartet:       " 12:34:56 ",
+			erwartetFehler: false,
+		},
+	}
+
+	for _, tt := range tests {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(tt.html))
+		}))
+		defer ts.Close()
+
+		t.Run(tt.name, func(t *testing.T) {
+			ergebnis, err := FetchTimeFromWeb(ts.URL)
+			if tt.erwartetFehler {
+				if err == nil {
+					t.Errorf("Erwarteter Fehler, aber keiner erhalten. Ergebnis: %q", ergebnis)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unerwarteter Fehler: %v", err)
+				}
+				if ergebnis != tt.erwartet {
+					t.Errorf("Erwartet: %q, erhalten: %q", tt.erwartet, ergebnis)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sets up the initial structure for a Go-based command-line tool designed for time tracking.

- Creates a basic CLI with `start`, `stop`, `status`, and `fetch` commands.
- Implements a `fetch` command to extract time data from web pages using an HTML parser.
- Adds initial Go module configuration and a basic CI workflow.